### PR TITLE
removing space between embedded and html

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       <ul>
         <li>Each exploration simulates a 1-on-1 interactive conversation with a tutor.</li>
         <li>Targeted feedback can be given to learners based on their respective answers.</li>
-        <li>Explorations can be <a href="embedded .html">embedded in any webpage.</a></li>
+        <li>Explorations can be <a href="embedded.html">embedded in any webpage.</a></li>
         <li><a href="improve.html">Analytics dashboards</a> highlight common problems and allow explorations to be improved over time.</li>
         <li>Learners can leave feedback on explorations for the authors to address.</li>
         <li>Explorations can be easily <a href="customized.html">customized</a> using a rich online editor.</li>


### PR DESCRIPTION
there was a space between the embedded html in the link at the index.html page which cause the bug. the link could not work
