### PR TITLE
Remved unused links and reduce the size of sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <head>
   <meta charset='utf-8'>
   <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <meta name="viewport" content="width=device-width, initial-state=1">
   <meta name="description" content="Oppia : A tool for creating interactive tutors">
   <link rel="stylesheet" type="text/css" media="screen" href="static/css/stylesheet.css">
   <!-- javascript -->

--- a/pages/home.html
+++ b/pages/home.html
@@ -49,10 +49,8 @@
   <h2><a id="helpful-links" class="anchor" href="#helpful-links" aria-hidden="true"><span class="octicon octicon-link"></span></a>Helpful Links</h2>
   <ul>
     <li><a href="https://github.com/oppia/oppia/wiki/Installing-Oppia-%28Linux%29">Getting started page</a></li>
-    <li>Index to Documentation (TODO: add link)</li>
     <li>Join the <a href="https://groups.google.com/forum/?fromgroups#!forum/oppia">discussion forum</a> or subscribe to the <a href="https://groups.google.com/forum/?fromgroups#!forum/oppia-announce">announcements list</a>
     </li>
-    <li>Development Status (TODO: add link)</li>
     <li><a href="https://github.com/oppia/oppia/issues/new">Report a bug</a></li>
   </ul>
   <p>

--- a/static/css/sidebar.css
+++ b/static/css/sidebar.css
@@ -1,8 +1,7 @@
 #sidebar {
   float: left;
   padding-top: 40px;
-  padding-left: 5%;
-  min-width: 240px;
+  min-width: 180px;
   margin: 0 auto;
 }
 

--- a/static/css/stylesheet.css
+++ b/static/css/stylesheet.css
@@ -462,7 +462,7 @@ Full-Width Styles
 }
 
 .container {
-  width: 990px;
+  width: 1024px;
   margin: 0 auto;
   boxing-size: border-box;
   /*for page with few content sidebar touches footer
@@ -537,5 +537,8 @@ Small Device Styles
 @media screen and (max-width: 640px) {
   img {
     width: 640px;
+  }
+  .container{
+    width:990px;
   }
 }


### PR DESCRIPTION
I increased the size of the container for large screen devices  and kept the orignall for small devices. Reduce the minimum size of sidebar tbut below that content starts to scrunch around the sidebar.
