### PR TITLE
Update server instructions for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Fork and clone this repo, then run
 
 or
 
-
 **Python 3:**
 ```
    python -m http.server 8181

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Angular application.
 Fork and clone this repo, then run
 
 ```
-   python -m SimpleHTTPServer 8181
+   python -m http.server 8181
 ```
 
 Then navigate to `localhost:8181` in a browser.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Angular application.
 
 Fork and clone this repo, then run
 
+**Python 2:**
+```
+   python -m SimpleHTTPServer 8181
+```
+
+or
+
+
+**Python 3:**
 ```
    python -m http.server 8181
 ```


### PR DESCRIPTION
The simple HTTP server module in Python 3 is 'http.server' not 'SimpleHTTPServer'. See: https://docs.python.org/3/library/http.server.html.